### PR TITLE
fix: correct critical typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # Project Simulator
-implimentation
+implementation


### PR DESCRIPTION
- Changed 'implimentation' to 'implementation'
- This was causing confusion for users